### PR TITLE
update toSlack.js to use bot_access_token

### DIFF
--- a/authorize.js
+++ b/authorize.js
@@ -101,8 +101,8 @@ module.exports.authorize = (event, ctx) => {
       name: body.team_name,
       scope: body.scope,
       access_token: body.access_token,
-      bot_user_id: body.bot_user_id,
-      bot_access_token: body.bot_access_token,
+      bot_user_id: body.bot.bot_user_id,
+      bot_access_token: body.bot.bot_access_token,
       incoming_webhook_url: body.incoming_webhook.url,
       incoming_webhook_channel: body.incoming_webhook.channel,
       incoming_webhook_configuration_url: body.incoming_webhook.configuration_url

--- a/toSlack.js
+++ b/toSlack.js
@@ -31,7 +31,7 @@ module.exports.sendData = (event, context) => {
       console.log('This team has no access token')
       return
     }
-    let slack = new Slack(data.Item.access_token)
+    let slack = new Slack(data.Item.bot_access_token)
 
     // Messaging service
     slack.api(event.slackCommand, event.body, (err, res) => {

--- a/toSlack.js
+++ b/toSlack.js
@@ -27,8 +27,8 @@ module.exports.sendData = (event, context) => {
       return console.log('There was an Error ', JSON.stringify(err, null, 2))
     }
     console.log('Found this record ', JSON.stringify(data, null, 2))
-    if (!data.Item.access_token) {
-      console.log('This team has no access token')
+    if (!data.Item.bot_access_token) {
+      console.log('This team has no bot access token')
       return
     }
     let slack = new Slack(data.Item.bot_access_token)


### PR DESCRIPTION
https://api.slack.com/docs/oauth

> Bot user access tokens
> If your Slack app includes a bot user, upon approval the JSON response will contain an additional node containing an access token to be specifically used for your bot user, within the context of the approving team.
